### PR TITLE
Change Astarte timestamp value to ms

### DIFF
--- a/include/edgehog_device/result.h
+++ b/include/edgehog_device/result.h
@@ -87,6 +87,8 @@ typedef enum
     EDGEHOG_RESULT_TELEMETRY_STORE_FAIL = 31,
     /** @brief Unable to stop a telemetry entry. */
     EDGEHOG_RESULT_TELEMETRY_STOP_FAIL = 32,
+    /** @brief A function has been called with incorrect parameters. */
+    EDGEHOG_RESULT_INVALID_PARAM = 33,
 
 } edgehog_result_t;
 

--- a/lib/edgehog_device/battery_status.c
+++ b/lib/edgehog_device/battery_status.c
@@ -8,8 +8,7 @@
 
 #include "edgehog_private.h"
 #include "generated_interfaces.h"
-
-#include <time.h>
+#include "system_time.h"
 
 #include <astarte_device_sdk/device.h>
 #include <astarte_device_sdk/result.h>
@@ -48,7 +47,8 @@ edgehog_result_t edgehog_battery_status_publish(
             .individual = astarte_individual_from_double(battery_status->level_absolute_error) },
         { .path = "status", .individual = astarte_individual_from_string(battery_state) } };
 
-    const int64_t timestamp = (int64_t) time(NULL);
+    int64_t timestamp_ms = 0;
+    system_time_current_ms(&timestamp_ms);
 
     size_t path_size = strlen(battery_status->battery_slot) + 2;
     char path[path_size];
@@ -62,7 +62,7 @@ edgehog_result_t edgehog_battery_status_publish(
 
     astarte_result_t res = astarte_device_stream_aggregated(edgehog_device->astarte_device,
         io_edgehog_devicemanager_BatteryStatus.name, path, object_entries,
-        ARRAY_SIZE(object_entries), &timestamp);
+        ARRAY_SIZE(object_entries), &timestamp_ms);
     if (res != ASTARTE_RESULT_OK) {
         EDGEHOG_LOG_ERR("Unable to send battery status");
         return EDGEHOG_RESULT_ASTARTE_ERROR;

--- a/lib/edgehog_device/include/system_time.h
+++ b/lib/edgehog_device/include/system_time.h
@@ -1,0 +1,36 @@
+/*
+ * (C) Copyright 2024, SECO Mind Srl
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SYSTEM_TIME_H
+#define SYSTEM_TIME_H
+
+/**
+ * @file system_time.h
+ * @brief System time utility functions
+ */
+
+#include "edgehog_device/result.h"
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Gets the current system time in milliseconds.
+ *
+ * @param[out] timestamp_ms The current time value in ms.
+ *
+ * @return EDGEHOG_RESULT_OK if successful, otherwise an error code.
+ */
+edgehog_result_t system_time_current_ms(int64_t *timestamp_ms);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSTEM_TIME_H */

--- a/lib/edgehog_device/ota.c
+++ b/lib/edgehog_device/ota.c
@@ -12,10 +12,9 @@
 #include "generated_interfaces.h"
 #include "http.h"
 #include "settings.h"
+#include "system_time.h"
 
 #include <stdlib.h>
-
-#include <time.h>
 
 #include <zephyr/device.h>
 #include <zephyr/dfu/flash_img.h>
@@ -758,11 +757,12 @@ static void pub_ota_event(astarte_device_handle_t astarte_device, const char *re
         { .path = "message", .individual = astarte_individual_from_string(message) },
     };
 
-    const int64_t timestamp = (int64_t) time(NULL);
+    int64_t timestamp_ms = 0;
+    system_time_current_ms(&timestamp_ms);
 
     astarte_result_t res
         = astarte_device_stream_aggregated(astarte_device, io_edgehog_devicemanager_OTAEvent.name,
-            "/event", object_entries, ARRAY_SIZE(object_entries), &timestamp);
+            "/event", object_entries, ARRAY_SIZE(object_entries), &timestamp_ms);
     if (res != ASTARTE_RESULT_OK) {
         EDGEHOG_LOG_ERR("Unable to send ota_event"); // NOLINT
     }

--- a/lib/edgehog_device/storage_usage.c
+++ b/lib/edgehog_device/storage_usage.c
@@ -8,8 +8,7 @@
 
 #include "edgehog_private.h"
 #include "nvs.h"
-
-#include <time.h>
+#include "system_time.h"
 
 #include <astarte_device_sdk/device.h>
 #include <astarte_device_sdk/result.h>
@@ -31,11 +30,12 @@ void publish_storage_usage(edgehog_device_handle_t edgehog_device)
             { .path = "freeBytes", .individual = astarte_individual_from_longinteger(free_space) }
         };
 
-        const int64_t timestamp = (int64_t) time(NULL);
+        int64_t timestamp_ms = 0;
+        system_time_current_ms(&timestamp_ms);
 
         astarte_result_t res = astarte_device_stream_aggregated(edgehog_device->astarte_device,
             io_edgehog_devicemanager_StorageUsage.name, "/" NVS_PARTITION_LABEL, object_entries,
-            ARRAY_SIZE(object_entries), &timestamp);
+            ARRAY_SIZE(object_entries), &timestamp_ms);
         if (res != ASTARTE_RESULT_OK) {
             EDGEHOG_LOG_ERR("Unable to send syste_status"); // NOLINT
         }

--- a/lib/edgehog_device/system_status.c
+++ b/lib/edgehog_device/system_status.c
@@ -8,8 +8,7 @@
 
 #include "edgehog_private.h"
 #include "hardware_info.h"
-
-#include <time.h>
+#include "system_time.h"
 
 #include <zephyr/kernel.h>
 
@@ -73,11 +72,12 @@ void publish_system_status(edgehog_device_handle_t edgehog_device)
             .individual = astarte_individual_from_longinteger(k_uptime_get()) },
     };
 
-    const int64_t timestamp = (int64_t) time(NULL);
+    int64_t timestamp_ms = 0;
+    system_time_current_ms(&timestamp_ms);
 
     astarte_result_t res = astarte_device_stream_aggregated(edgehog_device->astarte_device,
         io_edgehog_devicemanager_SystemStatus.name, "/systemStatus", object_entries,
-        ARRAY_SIZE(object_entries), &timestamp);
+        ARRAY_SIZE(object_entries), &timestamp_ms);
     if (res != ASTARTE_RESULT_OK) {
         EDGEHOG_LOG_ERR("Unable to send system_status"); // NOLINT
     }

--- a/lib/edgehog_device/system_time.c
+++ b/lib/edgehog_device/system_time.c
@@ -1,0 +1,27 @@
+/*
+ * (C) Copyright 2024, SECO Mind Srl
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "system_time.h"
+
+#include <zephyr/posix/time.h>
+
+edgehog_result_t system_time_current_ms(int64_t *timestamp_ms)
+{
+    if (!timestamp_ms) {
+        return EDGEHOG_RESULT_INVALID_PARAM;
+    }
+
+    struct timespec tspec;
+    int res = clock_gettime(CLOCK_REALTIME, &tspec);
+
+    if (res != 0) {
+        return EDGEHOG_RESULT_INTERNAL_ERROR;
+    }
+
+    *timestamp_ms = (int64_t) tspec.tv_sec * MSEC_PER_SEC + (tspec.tv_nsec / NSEC_PER_MSEC);
+
+    return EDGEHOG_RESULT_OK;
+}

--- a/lib/edgehog_device/wifi_scan.c
+++ b/lib/edgehog_device/wifi_scan.c
@@ -10,7 +10,7 @@
 
 #ifdef CONFIG_WIFI
 
-#include <time.h>
+#include "system_time.h"
 
 #include <zephyr/net/net_event.h>
 #include <zephyr/net/net_if.h>
@@ -121,7 +121,8 @@ static void handle_wifi_scan_result(astarte_device_handle_t astarte_device,
         return;
     }
 
-    const int64_t timestamp = (int64_t) time(NULL);
+    int64_t timestamp_ms = 0;
+    system_time_current_ms(&timestamp_ms);
 
     bool ap_is_connected
         = connected_ap_mac != NULL && strcmp(connected_ap_mac, mac_string_buf) == 0;
@@ -136,7 +137,7 @@ static void handle_wifi_scan_result(astarte_device_handle_t astarte_device,
 
     astarte_result_t res = astarte_device_stream_aggregated(astarte_device,
         io_edgehog_devicemanager_WiFiScanResults.name, "/ap", object_entries,
-        ARRAY_SIZE(object_entries), &timestamp);
+        ARRAY_SIZE(object_entries), &timestamp_ms);
     if (res != ASTARTE_RESULT_OK) {
         EDGEHOG_LOG_ERR("Unable to send WiFiScanResults"); // NOLINT
     }

--- a/samples/simple/src/main.c
+++ b/samples/simple/src/main.c
@@ -344,7 +344,7 @@ static void astarte_disconnection_events_handler(astarte_device_disconnection_ev
 
 static void system_time_init()
 {
-#ifdef CONFIG_NET_CONFIG_SNTP_INIT
+#ifdef CONFIG_SNTP
     int ret = 0;
     struct sntp_time now;
     struct timespec tspec;


### PR DESCRIPTION
Timestamp returned by TIME function is expressed in seconds, meanwhile Astarte SDK is in milliseconds.

Add utility function to get current system time in ms.